### PR TITLE
Add `no_muxer=1` for searching subtitle

### DIFF
--- a/src/services/subtitle.shooter_fake.js
+++ b/src/services/subtitle.shooter_fake.js
@@ -2,7 +2,7 @@ export var name = '射手网 (伪)'
 
 export function search (name) {
   let token = window.app.config.subtitleServices.shooterFake.token
-  return window.fetch(`http://api.assrt.net/v1/sub/search?token=${token}&q=${name}&cnt=10`)
+  return window.fetch(`http://api.assrt.net/v1/sub/search?token=${token}&q=${name}&cnt=10&no_muxer=1`)
   .then(res => res.json())
   .then(res => {
     if (res.sub.subs.length) return res.sub.subs


### PR DESCRIPTION
目前glutton使用`/.*(?=.\b\d{3,4}p)/i`来割掉文件名中的分辨率及之后的字符串，对于某些如"a.b.INTERNAL.720p.c.d-GROUP"以及非标准命名的文件可能还是搜不到结果。

assrt.net[最近更新了](http://assrt.net/api/doc#subsearch)`no_muxer=1`的新参数可以割掉这些关键词 😃 
